### PR TITLE
async request for cors

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -1367,7 +1367,7 @@
         data.append(this.flowObj.opts.fileParameterName, blob);
       }
 
-      this.xhr.open(method, target);
+      this.xhr.open(method, target, true);
       this.xhr.withCredentials = this.flowObj.opts.withCredentials;
 
       // Add data from header options


### PR DESCRIPTION
I faced this error with FF 28.0

> [Exception... "A parameter or an operation is not supported by the underlying object" code: "15" nsresult: "0x8053000f (InvalidAccessError)" location: ""]

while trying to make an CORS request.

Similar problem is described here http://stackoverflow.com/questions/16677893/evil-firefox-error-a-parameter-or-an-operation-is-not-supported-by-the-under

I solved it adding 3rd parameter for async in your code line 1370

> this.xhr.open(method, target, true);
