### PR TITLE
Use original filename in node sample post callback.

### DIFF
--- a/samples/Node.js/flow-node.js
+++ b/samples/Node.js/flow-node.js
@@ -98,12 +98,12 @@ module.exports = flow = function(temporaryFolder) {
         var identifier = cleanIdentifier(fields['flowIdentifier']);
         var filename = fields['flowFilename'];
 
-        var original_filename = fields['flowIdentifier'];
-
         if (!files[$.fileParameterName] || !files[$.fileParameterName].size) {
             callback('invalid_flow_request', null, null, null);
             return;
         }
+
+        var original_filename = files[$.fileParameterName]['originalFilename'];
         var validation = validateRequest(chunkNumber, chunkSize, totalSize, identifier, filename, files[$.fileParameterName].size);
         if (validation == 'valid') {
             var chunkFilename = getChunkFilename(chunkNumber, identifier);


### PR DESCRIPTION
This change enables saving the uploaded file with correct filename using the write method of `flow.write`.

``` javascript
flow.post(req, function(status, filename, originalFilename, identifier) {
  if (status === 'done') {
    var stream = fs.createWriteStream(__dirname + '/../images/' + originalFilename);
    flow.write(identifier, stream);
    stream.on('finish', function() {
      console.log('Finished writing ' + originalFilename);
    });
  }
});
```
