### PR TITLE
Accept the HTTP 201 (created) as success

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -1302,9 +1302,10 @@
         // or 'LOADING' - meaning that stuff is happening
         return 'uploading';
       } else {
-        if (this.xhr.status == 200 || this.xhr.status == 202) {
+        if (this.xhr.status == 200 || this.xhr.status == 201 || this.xhr.status == 202) {
           // HTTP 200, perfect
-		  // HTTP 202 Accepted - The request has been accepted for processing, but the processing has not been completed.
+          // HTTP 201, Created - The request has been fulfilled and resulted in a new resource (in this case the file) being created.
+          // HTTP 202, Accepted - The request has been accepted for processing, but the processing has not been completed.
           return 'success';
         } else if (this.flowObj.opts.permanentErrors.indexOf(this.xhr.status) > -1 ||
             this.retries >= this.flowObj.opts.maxChunkRetries) {


### PR DESCRIPTION
If the server responds with a 201 status, it means that it has successfully created the resource (in this case the file being uploaded) so it should be a success case in the status function.
