### PR TITLE
Minor fix in node clean method

### DIFF
--- a/samples/Node.js/flow-node.js
+++ b/samples/Node.js/flow-node.js
@@ -191,7 +191,7 @@ module.exports = flow = function(temporaryFolder) {
 
                     console.log('exist removing ', chunkFilename);
                     fs.unlink(chunkFilename, function(err) {
-                        if (options.onError) options.onError(err);
+                        if (err && options.onError) options.onError(err);
                     });
 
                     pipeChunkRm(number + 1);


### PR DESCRIPTION
The `$.clean` `onError` callback is only invoked if an exception has actually been passed to the `fs.unlink()` callback.
