### PR TITLE
Remove dot from package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "flow.js",
+  "name": "flow-js",
   "version": "2.8.0",
   "main": "./dist/flow.js",
   "ignore": [


### PR DESCRIPTION
I believe this would resolve flowjs/ng-flow/issues/110 and #73 

This will require updating packages that depend on it, of course.