### PR TITLE
Fix event callback context

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -199,7 +199,7 @@
       if (this.events.hasOwnProperty(event)) {
         each(this.events[event], function (callback) {
           preventDefault = callback.apply(this, args.slice(1)) === false || preventDefault;
-        });
+        }, this);
       }
       if (event != 'catchall') {
         args.unshift('catchAll');

--- a/test/eventsSpec.js
+++ b/test/eventsSpec.js
@@ -17,6 +17,15 @@ describe('events', function() {
     expect(valid).toBeTruthy();
   });
 
+  it('should have a context of flow instance', function() {
+    var context = null;
+    flow.on('test', function () {
+      context = this;
+    });
+    flow.fire('test');
+    expect(context).toEqual(flow);
+  });
+
   it('should pass some arguments', function() {
     var valid = false;
     var argumentOne = 123;


### PR DESCRIPTION
When event callbacks are executed, they are not executed with the context of the flow instance; instead 'this' refers to the window object.

[+] Added fix to pass 'this' context when fire method is executing callbacks.
[+] Added test to check context of this. All existing tests pass as well.

Cheers =)

