### PR TITLE
Setting width and height of input element type 1px

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -371,7 +371,9 @@
           // display:none - not working in opera 12
           extend(input.style, {
             visibility: 'hidden',
-            position: 'absolute'
+            position: 'absolute',
+            width: '1px',
+            height: '1px'
           });
           // for opera 12 browser, input must be assigned to a document
           domNode.appendChild(input);


### PR DESCRIPTION
I noticed that due to a bug in Opera 12, we are now using visibility attribute instead of the display attribute. 

It would be better to set the width and height  to a minimal value, otherwise it causes the horizontal scrollbar to show if the flow button is added on the right edge of the screen.