### PR TITLE
Allow reupload of same file once the upload is complete

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -371,7 +371,9 @@
           // display:none - not working in opera 12
           extend(input.style, {
             visibility: 'hidden',
-            position: 'absolute'
+            position: 'absolute',
+            width: '1px',
+            height: '1px'
           });
           // for opera 12 browser, input must be assigned to a document
           domNode.appendChild(input);

--- a/src/flow.js
+++ b/src/flow.js
@@ -572,7 +572,7 @@
         // Directories have size `0` and name `.`
         // Ignore already added files if opts.allowDuplicateUploads is set to false
         if ((!ie10plus || ie10plus && file.size > 0) && !(file.size % 4096 === 0 && (file.name === '.' || file.fileName === '.')) &&
-          (opts.allowDuplicateUploads || !this.getFromUniqueIdentifier(this.generateUniqueIdentifier(file)))) {
+          (this.opts.allowDuplicateUploads || !this.getFromUniqueIdentifier(this.generateUniqueIdentifier(file)))) {
           var f = new FlowFile(this, file);
           if (this.fire('fileAdded', f, event)) {
             files.push(f);


### PR DESCRIPTION
Adding an option to override the default behavior of ignore reupload of the same file.