### PR TITLE
Don't call addFiles when there are no files to add.

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -403,8 +403,10 @@
         // When new files are added, simply append them to the overall list
         var $ = this;
         input.addEventListener('change', function (e) {
-          $.addFiles(e.target.files, e);
-          e.target.value = '';
+       	  if (e.target.value) {
+            $.addFiles(e.target.files, e);
+            e.target.value = '';
+       	  }
         }, false);
       }, this);
     },

--- a/test/setupSpec.js
+++ b/test/setupSpec.js
@@ -69,7 +69,7 @@ describe('setup', function() {
       var event = document.createEvent('MouseEvents');
       event.initEvent('change', true, true);
       input.dispatchEvent(event);
-      expect(addFiles).toHaveBeenCalled();
+      expect(addFiles).not.toHaveBeenCalled();
     });
 
     it('assign to div', function() {
@@ -83,7 +83,7 @@ describe('setup', function() {
       var event = document.createEvent('MouseEvents');
       event.initEvent('change', true, true);
       input.dispatchEvent(event);
-      expect(addFiles).toHaveBeenCalled();
+      expect(addFiles).not.toHaveBeenCalled();
     });
 
     it('single file', function() {


### PR DESCRIPTION
Had a problem where change events are firing on focus loss even though there are no files to add.  So I added a check to not run the addFiles flow if there are no files to add.