### PR TITLE
Add queue limit.

### DIFF
--- a/test/fileAddSpec.js
+++ b/test/fileAddSpec.js
@@ -62,4 +62,23 @@ describe('fileAdd event', function() {
     flow.addFile(new Blob(['file part']));
     expect(valid).toBeTruthy();
   });
+
+  it('should only add files up to the queue limit', function(){
+    flow.opts.queueLimit = 1
+    flow.addFile(new Blob(['file part']));
+    flow.addFile(new Blob(['another file part']));
+
+    expect(flow.files.length).toBe(1)
+  });
+
+  it('should trigger an error on file upload limit reached', function(){
+    var eventHandler = jasmine.createSpy('event');
+    flow.opts.queueLimit = 1
+    flow.on('queueLimitExceeded', eventHandler);
+      
+    flow.addFile(new Blob(['file part']));
+    flow.addFile(new Blob(['another file part']));
+
+    expect(eventHandler).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
It's nice to be able to restrict the maximum number of files that can be uploaded in one batch. If the queue limit is exceeded, an event is fired allowing the consumer to display a message to the user. 