### PR TITLE
Add unAssignDrop to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ parameter must be adjusted together with `progressCallbacksInterval` parameter. 
 
    Note: avoid using `a` and `button` tags as file upload buttons, use span instead.
 * `.assignDrop(domNodes)` Assign one or more DOM nodes as a drop target.
+* `.unAssignDrop(domNodes)` Unassign one or more DOM nodes as a drop target.
 * `.on(event, callback)` Listen for event from Flow.js (see below)
 * `.off([event, [callback]])`:
     * `.off()` All events are removed.


### PR DESCRIPTION
Couldn't find it, but I figured it needs to be there because assigning a drop target doesn't do any DOM manipulations. 
Anyway, it took me some time to find it in the source & it would be a time-saver for others looking for it.

Ref.: https://github.com/flowjs/flow.js/blob/master/src/flow.js#L435-L444