### PR TITLE
Fix incorrect supportDirectory flag for Safari 

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -57,7 +57,7 @@
      * Check if directory upload is supported
      * @type {boolean}
      */
-    this.supportDirectory = /WebKit/.test(window.navigator.userAgent);
+    this.supportDirectory = /Chrome/.test(window.navigator.userAgent);
 
     /**
      * List of FlowFile objects


### PR DESCRIPTION
When we look for "WebKit" in the userAgent string, Safari passes even though it does not support directory uploads. 

Since only Chrome supports directory upload right now, let's just test for Chrome instead.

This fixes #124 