### PR TITLE
Add unit-tests for fileRemove event.

### DIFF
--- a/test/fileRemoveSpec.js
+++ b/test/fileRemoveSpec.js
@@ -1,0 +1,45 @@
+describe('fileRemoved event', function() {
+  /**
+   * @type {Flow}
+   */
+  var flow;
+
+  beforeEach(function () {
+    flow = new Flow({
+      generateUniqueIdentifier: function (file) {
+        return file.size;
+      }
+    });
+  });
+
+  it('should call fileRemoved event on Flow.removeFile', function() {
+    var valid = false;
+    var removedFile = null;
+    flow.on('fileRemoved', function (file) {
+      expect(file.file instanceof Blob).toBeTruthy();
+      removedFile = file;
+      valid = true;
+    });
+    flow.addFile(new Blob(['file part']));
+    var addedFile = flow.files[0];
+    flow.removeFile(addedFile);
+    expect(removedFile).toBe(addedFile);
+    expect(valid).toBeTruthy();
+  });
+  
+  it('should call fileRemoved event FlowFile.cancel', function() {
+    var valid = false;
+    var removedFile = null;
+    flow.on('fileRemoved', function (file) {
+      expect(file.file instanceof Blob).toBeTruthy();
+      removedFile = file;
+      valid = true;
+    });
+    flow.addFile(new Blob(['file part']));
+    var addedFile = flow.files[0];
+    addedFile.cancel();
+    expect(removedFile).toBe(addedFile);
+    expect(valid).toBeTruthy();
+  });  
+
+});

--- a/test/singleFileSpec.js
+++ b/test/singleFileSpec.js
@@ -23,4 +23,29 @@ describe('add single file', function() {
     expect(flow.files.length).toBe(1);
     expect(file.isUploading()).toBeFalsy();
   });
+  
+  it('should fire remove event after adding another file', function(){
+    var events = [];
+    flow.on('catchAll', function (event) {
+        events.push(event);
+    });
+    flow.addFile(new Blob(['file part']));
+    expect(flow.files.length).toBe(1);
+    expect(events.length).toBe(3);
+    expect(events[0]).toBe('fileAdded');
+    expect(events[1]).toBe('filesAdded');
+    expect(events[2]).toBe('filesSubmitted');
+    
+    var removedFile = flow.files[0];
+    flow.on('fileRemoved', function(file){
+        expect(file).toBe(removedFile); 
+    });
+    flow.addFile(new Blob(['file part 2']));
+    expect(flow.files.length).toBe(1);
+    expect(events.length).toBe(7);
+    expect(events[3]).toBe('fileAdded');
+    expect(events[4]).toBe('filesAdded');
+    expect(events[5]).toBe('fileRemoved');
+    expect(events[6]).toBe('filesSubmitted');
+  });
 });


### PR DESCRIPTION
Rebased version of #166
Added unit-tests for fileRemoved event.
Testing three cases that should fire fileRemoved event.
1. Adding a second file when in single-file mode.
2. Calling Flow.removeFile.
3. Calling FlowFile.cancel.

Test involves checking if the event if fired, and if the first argument passed in is the FlowFile being removed.