### PR TITLE
Add HTTP code 413 as permanent error

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -91,7 +91,7 @@
       generateUniqueIdentifier: null,
       maxChunkRetries: 0,
       chunkRetryInterval: null,
-      permanentErrors: [404, 415, 500, 501],
+      permanentErrors: [404, 413, 415, 500, 501],
       successStatuses: [200, 201, 202],
       onDropStopPropagation: false,
       initFileFn: null,
@@ -1400,7 +1400,7 @@
           return 'success';
         } else if (this.flowObj.opts.permanentErrors.indexOf(this.xhr.status) > -1 ||
             !isTest && this.retries >= this.flowObj.opts.maxChunkRetries) {
-          // HTTP 415/500/501, permanent error
+          // HTTP 413/415/500/501, permanent error
           return 'error';
         } else {
           // this should never happen, but we'll reset and queue a retry


### PR DESCRIPTION
Code 413 is defined as "Payload Too Large" (The request is larger than the server is willing or able to process).
https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error

This might be needed when the backend responds that it's either entirely out of space or the request exceeds the quota.
Neither of the previous permanent errors (415, 500, 501) corresponded to this situation.

A slight rephrasing of the section concerning those errors in README.md might be needed, too.