### PR TITLE
Node.js example status fix #177

### DIFF
--- a/samples/Node.js/app.js
+++ b/samples/Node.js/app.js
@@ -20,7 +20,7 @@ app.post('/upload', multipartMiddleware, function(req, res) {
     if (ACCESS_CONTROLL_ALLOW_ORIGIN) {
       res.header("Access-Control-Allow-Origin", "*");
     }
-    res.status(status).send();
+    res.status(/^(partly_done|done)$/.test(status) ? 200 : 500).send();
   });
 });
 


### PR DESCRIPTION
Fixes #177 

The nodejs example was sending the text status from flow.post to express. Replaced with a regular expression to test for good values. 

If the callback was changed to send back null on success we could follow the callback(err, results) convention and do something like this:

``` js
app.post('/upload', multipartMiddleware, function(req, res) {
  flow.post(req, function(error, filename, original_filename, identifier) {
    console.log('POST', error, original_filename, identifier);
    if (ACCESS_CONTROLL_ALLOW_ORIGIN) {
      res.header("Access-Control-Allow-Origin", "*");
    }
    res.status(error ? 500 : 200).send();
  });
});
```
