### PR TITLE
generateUniqueIdentifier change

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -285,7 +285,7 @@
       }
       // Some confusion in different versions of Firefox
       var relativePath = file.relativePath || file.webkitRelativePath || file.fileName || file.name;
-      return file.size + '-' + relativePath.replace(/[^0-9a-zA-Z_-]/img, '');
+      return file.size + '-' + relativePath.replace(/[^.0-9a-zA-Z_-]/img, '');
     },
 
     /**


### PR DESCRIPTION
When generating a unique filename, by default the generateUniqueIdentifier creates a filename replacing also the dots inside the relative path, so the resulting filename doesn't have an extension: this can be annoying, so I propose to keep the dots of the original filename when creating the unique identifier.
