### PR TITLE
fix nodejs sample post status

### DIFF
--- a/samples/Node.js/app.js
+++ b/samples/Node.js/app.js
@@ -20,6 +20,12 @@ app.post('/upload', multipartMiddleware, function(req, res) {
     if (ACCESS_CONTROLL_ALLOW_ORIGIN) {
       res.header("Access-Control-Allow-Origin", "*");
     }
+    if(/done/.test(status)) {
+      status = 200;
+    }
+    else {
+      status = 500;
+    }
     res.status(status).send();
   });
 });


### PR DESCRIPTION
The status in the callback of `$.post` is a string.
