### PR TITLE
Add directory upload support to Firefox and Edge

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -57,7 +57,11 @@
      * Check if directory upload is supported
      * @type {boolean}
      */
-    this.supportDirectory = /Chrome/.test(window.navigator.userAgent);
+    this.supportDirectory = (
+        /Chrome/.test(window.navigator.userAgent) ||
+        /Firefox/.test(window.navigator.userAgent) ||
+        /Edge/.test(window.navigator.userAgent)
+    );
 
     /**
      * List of FlowFile objects


### PR DESCRIPTION
In [Firefox 50](https://developer.mozilla.org/en-US/Firefox/Releases/50) Mozilla added support for directory upload.

Microsoft Edge seems to have had support for it since [Windows 10 build 14316](https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14316/).