### PR TITLE
Minor fix to the Nodejs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Startup
+
+`node samples/Node.js/app.js`
+
 # Flow.js [![Build Status](https://travis-ci.org/flowjs/flow.js.svg)](https://travis-ci.org/flowjs/flow.js) [![Test Coverage](https://codeclimate.com/github/flowjs/flow.js/badges/coverage.svg)](https://codeclimate.com/github/flowjs/flow.js/coverage)
 
 [![Saucelabs Test Status](https://saucelabs.com/browser-matrix/flowjs.svg)](https://saucelabs.com/u/flowjs)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Startup
+# Vixlet Startup
 
-`node samples/Node.js/app.js`
+Add the Bearer token here: https://github.com/haivixlet/flow.js/blob/master/samples/Node.js/public/index.html#L57
+
+Start the server: `node samples/Node.js/app.js`
+
+Navigate to http://localhost:3000/index.html
 
 # Flow.js [![Build Status](https://travis-ci.org/flowjs/flow.js.svg)](https://travis-ci.org/flowjs/flow.js) [![Test Coverage](https://codeclimate.com/github/flowjs/flow.js/badges/coverage.svg)](https://codeclimate.com/github/flowjs/flow.js/coverage)
 

--- a/samples/Node.js/app.js
+++ b/samples/Node.js/app.js
@@ -56,4 +56,6 @@ app.get('/download/:identifier', function(req, res) {
   flow.write(req.params.identifier, res);
 });
 
-app.listen(3000);
+app.listen(3000, function() {
+  console.log('Started');
+});

--- a/samples/Node.js/app.js
+++ b/samples/Node.js/app.js
@@ -20,7 +20,8 @@ app.post('/upload', multipartMiddleware, function(req, res) {
     if (ACCESS_CONTROLL_ALLOW_ORIGIN) {
       res.header("Access-Control-Allow-Origin", "*");
     }
-    res.status(status).send();
+    //res.status(status).send()
+    res.status(/^(partly_done|done)$/.test(status) ? 200 : 500).send();
   });
 });
 

--- a/samples/Node.js/public/index.html
+++ b/samples/Node.js/public/index.html
@@ -48,9 +48,15 @@
       <script>
         (function () {
           var r = new Flow({
-            target: '/upload',
-            chunkSize: 1024*1024,
-            testChunks: false
+            target: 'http://uploader.vixletinternal.com/',
+            chunkSize: 5 * 1024 * 1024,
+            testChunks: false,
+            headers: {
+              'Accept-Version': '4.1.0',
+              'Domain': '9999',
+              'Authorization': 'Bearer xxxxx'
+            },
+            simultaneousUploads: 3
           });
           // Flow.js isn't supported, fall back on a different method
           if (!r.support) {


### PR DESCRIPTION
Express was throwing the Invalid status code error because flow was sending "partly_done" status.
The fix allow for the app to successfully work.

_http_server.js:192
    throw new RangeError(`Invalid status code: ${statusCode}`);
    ^

RangeError: Invalid status code: 0
    at ServerResponse.writeHead (_http_server.js:192:11)
    at ServerResponse._implicitHeader (_http_server.js:157:8)
    at ServerResponse.OutgoingMessage.end (_http_outgoing.js:559:10)
    at ServerResponse.send (/Users/hai.nguyen/workspace/flow.js/samples/Node.js/node_modules/express/lib/response.js:205:10)
    at /Users/hai.nguyen/workspace/flow.js/samples/Node.js/app.js:23:24
    at /Users/hai.nguyen/workspace/flow.js/samples/Node.js/flow-node.js:122:33
    at FSReqWrap.cb [as oncomplete] (fs.js:257:19)