### PR TITLE
Avoid ReferenceError window is not defined in the node environment

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -2,6 +2,10 @@
  * @license MIT
  */
 (function(window, document, undefined) {'use strict';
+  if (!window || !document) {
+    console.warn('Flowjs needs window and document objects to work');
+    return;
+  }
   // ie10+
   var ie10plus = window.navigator.msPointerEnabled;
   /**
@@ -1632,4 +1636,4 @@
       define( "flow", [], function () { return Flow; } );
     }
   }
-})(window, document);
+})(typeof window !== 'undefined' && window, typeof document !== 'undefined' && document);


### PR DESCRIPTION
To solve [issue with server side rendering](https://github.com/flowjs/ngx-flow/issues/7) I need flow.js to be able to survive missing `window` and `document` objects.

I am not sure how to cover this by tests however :-( any suggestions?