### PR TITLE
Do not modify the query string if there are no params to add

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -1283,6 +1283,10 @@
      * @returns {string}
      */
     getTarget: function(target, params){
+      if (params.length == 0) {
+	return target;
+      }
+
       if(target.indexOf('?') < 0) {
         target += '?';
       } else {


### PR DESCRIPTION
In getTarget, we assume `params` isn't empty and always add a '?' or a '&'.

However, in my case, I'm using flow to upload directly to Amazon AWS S3/CloudFront, using SignedURL. Their multipart upload API is somewhat different from the one flow usually has.

I'm overriding `opts.query` and `opts.target` to return the correct URLs. Up to now, Amazon was accepting the URLs even with the additional '&'. However, since a few days, they've tighten their validation of SignedURL.

Since the URLs are signed and sent with the query string already in the URL to the client, I would need to parse the query string and split `query` and `target` again. Since I have no guarantee the URL generated that way would be identical to the one I Signed previously, this wouldn't solve my issue.
It seems hardly justifiable to modify the URL when there are no `params` to add to it anyway.