### PR TITLE
handle Success status better

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -100,7 +100,7 @@
       maxChunkRetries: 0,
       chunkRetryInterval: null,
       permanentErrors: [404, 413, 415, 500, 501],
-      successStatuses: [200, 201, 202],
+      successStatuses: [200, 201, 202, 204],
       onDropStopPropagation: false,
       initFileFn: null,
       readFileFn: webAPIFileRead


### PR DESCRIPTION
     * added missing 204 to successstatuses.
     * this is to make library handle success better because some service will return 204 status by default.