### PR TITLE
Add new functionality to calculate chunk size dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ Available configuration options are:
 * `target` The target URL for the multipart POST request. This can be a string or a function. If a
 function, it will be passed a FlowFile, a FlowChunk and isTest boolean (Default: `/`)
 * `singleFile` Enable single file upload. Once one file is uploaded, second file will overtake existing one, first one will be canceled. (Default: false)
-* `chunkSize` The size in bytes of each uploaded chunk of data. The last uploaded chunk will be at least this size and up to two the size, see [Issue #51](https://github.com/23/resumable.js/issues/51) for details and reasons. (Default: `1*1024*1024`)
-* `calculateChunkSize` Optional function to set chunk size for each file. When this method is defined, chunkSize value will not be considered. File Object will be passed to it and it should return the size (in bytes) of chunks for that file.
+* `chunkSize` The size in bytes of each uploaded chunk of data. This can be a number or a function. If a function, it will be passed a FlowFile. The last uploaded chunk will be at least this size and up to two the size, see [Issue #51](https://github.com/23/resumable.js/issues/51) for details and reasons. (Default: `1*1024*1024`, 1MB)
 * `forceChunkSize` Force all chunks to be less or equal than chunkSize. Otherwise, the last chunk will be greater than or equal to `chunkSize`. (Default: `false`)
 * `simultaneousUploads` Number of simultaneous uploads (Default: `3`)
 * `fileParameterName` The name of the multipart POST parameter to use for the file chunk  (Default: `file`)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Available configuration options are:
 function, it will be passed a FlowFile, a FlowChunk and isTest boolean (Default: `/`)
 * `singleFile` Enable single file upload. Once one file is uploaded, second file will overtake existing one, first one will be canceled. (Default: false)
 * `chunkSize` The size in bytes of each uploaded chunk of data. The last uploaded chunk will be at least this size and up to two the size, see [Issue #51](https://github.com/23/resumable.js/issues/51) for details and reasons. (Default: `1*1024*1024`)
+* `calculateChunkSize` Optional function to set chunk size for each file. When this method is defined, chunkSize value will not be considered. File Object will be passed to it and it should return the size (in bytes) of chunks for that file.
 * `forceChunkSize` Force all chunks to be less or equal than chunkSize. Otherwise, the last chunk will be greater than or equal to `chunkSize`. (Default: `false`)
 * `simultaneousUploads` Number of simultaneous uploads (Default: `3`)
 * `fileParameterName` The name of the multipart POST parameter to use for the file chunk  (Default: `file`)

--- a/src/flow.js
+++ b/src/flow.js
@@ -12,7 +12,7 @@
    * Flow.js is a library providing multiple simultaneous, stable and
    * resumable uploads via the HTML5 File API.
    * @param [opts]
-   * @param {number} [opts.chunkSize]
+   * @param {number|Function} [opts.chunkSize]
    * @param {bool} [opts.forceChunkSize]
    * @param {number} [opts.simultaneousUploads]
    * @param {bool} [opts.singleFile]
@@ -79,7 +79,6 @@
      */
     this.defaults = {
       chunkSize: 1024 * 1024,
-      calculateChunkSize: null,
       forceChunkSize: false,
       simultaneousUploads: 3,
       singleFile: false,
@@ -751,6 +750,12 @@
      * @type {string}
      */
     this.uniqueIdentifier = (uniqueIdentifier === undefined ? flowObj.generateUniqueIdentifier(file) : uniqueIdentifier);
+                        
+    /**
+     * Size of Each Chunk
+     * @type {number}
+     */
+    this.chunkSize = 0;
 
     /**
      * List of chunks
@@ -939,13 +944,9 @@
       // Rebuild stack of chunks from file
       this._prevProgress = 0;
       var round = this.flowObj.opts.forceChunkSize ? Math.ceil : Math.floor;
-      var calculateChunkSize = this.flowObj.opts.calculateChunkSize;
-      var chunkSize = this.flowObj.opts.chunkSize;
-      if (typeof calculateChunkSize === 'function') {
-        chunkSize = calculateChunkSize(this);
-      }
+      this.chunkSize = evalOpts(this.flowObj.opts.chunkSize, this);
       var chunks = Math.max(
-        round(this.size / chunkSize), 1
+        round(this.size / this.chunkSize), 1
       );
       for (var offset = 0; offset < chunks; offset++) {
         this.chunks.push(
@@ -1159,7 +1160,7 @@
      * Size of a chunk
      * @type {number}
      */
-    this.chunkSize = this.flowObj.opts.chunkSize;
+    this.chunkSize = this.fileObj.chunkSize;
 
     /**
      * Chunk start byte in a file
@@ -1273,7 +1274,7 @@
     getParams: function () {
       return {
         flowChunkNumber: this.offset + 1,
-        flowChunkSize: this.flowObj.opts.chunkSize,
+        flowChunkSize: this.chunkSize,
         flowCurrentChunkSize: this.endByte - this.startByte,
         flowTotalSize: this.fileObj.size,
         flowIdentifier: this.fileObj.uniqueIdentifier,

--- a/src/flow.js
+++ b/src/flow.js
@@ -79,6 +79,7 @@
      */
     this.defaults = {
       chunkSize: 1024 * 1024,
+      calculateChunkSize: null,
       forceChunkSize: false,
       simultaneousUploads: 3,
       singleFile: false,
@@ -938,8 +939,13 @@
       // Rebuild stack of chunks from file
       this._prevProgress = 0;
       var round = this.flowObj.opts.forceChunkSize ? Math.ceil : Math.floor;
+      var calculateChunkSize = this.flowObj.opts.calculateChunkSize;
+      var chunkSize = this.flowObj.opts.chunkSize;
+      if (typeof calculateChunkSize === 'function') {
+        chunkSize = calculateChunkSize(this);
+      }
       var chunks = Math.max(
-        round(this.size / this.flowObj.opts.chunkSize), 1
+        round(this.size / chunkSize), 1
       );
       for (var offset = 0; offset < chunks; offset++) {
         this.chunks.push(


### PR DESCRIPTION
Add `calculateChunkSize` option when the chunkSize cannot be predecided for all the files... So, this will be called if it is defined and fileObject is passed as a parameter, so the chunk size can be set for each file without creating a new instance of Flow.