### PR TITLE
Fix unable to upload dropped folder if any error occurs

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -272,6 +272,7 @@
         decrement();
       }
       function readError(fileError) {
+        decrement();
         throw fileError;
       }
       function decrement() {


### PR DESCRIPTION
This bug can be reproduced in Chrome 83.0.4103.61, Windows 10.0.18362. When dropped folder has any file with absolute paths which exceeds 260 chars, upload is canceled. It should be possible to upload other files. 
Firefox 76.0.1, Windows 10.0.18362 doesn't have this bug, but it will not upload files with absolute path which exceeds 260 chars.
Edge 44.18362.449.0, Windows 10.0.18362 uploads all files regardless of the absolute path length.