### PR TITLE
Per-chunk filenames

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -1170,6 +1170,12 @@
     this.startByte = this.offset * this.chunkSize;
 
     /**
+     * A specific filename for this chunk which otherwise default to the main name
+     * @type {string}
+     */
+    this.filename = null;
+
+    /**
       * Compute the endbyte in a file
       *
       */
@@ -1512,7 +1518,9 @@
         each(query, function (v, k) {
           data.append(k, v);
         });
-        if (typeof blob !== "undefined") data.append(this.flowObj.opts.fileParameterName, blob, this.fileObj.file.name);
+        if (typeof blob !== "undefined") {
+            data.append(this.flowObj.opts.fileParameterName, blob, this.filename || this.fileObj.file.name);
+        }
       }
 
       this.xhr.open(method, target, true);


### PR DESCRIPTION
Sample (use the `query` hook):
```js
query: (fileObj, chunk) => {
   // Upload "foobar.bin" first chunk at "segments/000-foobar.bin"
   chunk.filename = 'segments/' + chunk.offset.toString().padStart(3, 0) + '-' + fileObj.file.name;
}
```

Use-case: Flow.js can't create [post](https://docs.openstack.org/swift/pike/api/form_post_middleware.html) [DLO](https://docs.openstack.org/swift/latest/overview_large_objects.html#direct-api) on Openstack Swift [temporary URL](https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html) but it **can** upload chunks.

In order to later build a DLO, each chunk must be correctly named (for sorting purposes) and all must be uploaded under a specific prefix which is possible using the File [name](https://developer.mozilla.org/en-US/docs/Web/API/File/name) form-data property.

This commit allows flow.js to set user-determined, per-chunk, filenames.