### PR TITLE
Chrome's FileSystem API has a bug reading files from dropped folders or input dialog's selected folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ added.
 * `.fileRetry(file, chunk)` Something went wrong during upload of a specific file, uploading is being 
 retried.
 * `.fileError(file, message, chunk)` An error occurred during upload of a specific file.
+* `.readErrors(files, folders, event)` This event fires before fileAdded or filesAdded events only if errors occur while reading files or folders. First argument `files` is collection of files read errors, second argument `folders` is collection of folder read errors.
 * `.uploadStart()` Upload has been started on the Flow object.
 * `.complete()` Uploading completed.
 * `.progress()` Uploading progress.

--- a/src/flow.js
+++ b/src/flow.js
@@ -230,55 +230,109 @@
      */
     webkitReadDataTransfer: function (event) {
       var $ = this;
-      var queue = event.dataTransfer.items.length;
-      var files = [];
-      each(event.dataTransfer.items, function (item) {
-        var entry = item.webkitGetAsEntry();
-        if (!entry) {
-          decrement();
-          return ;
-        }
-        if (entry.isFile) {
-          // due to a bug in Chrome's File System API impl - #149735
-          fileReadSuccess(item.getAsFile(), entry.fullPath);
-        } else {
-          readDirectory(entry.createReader());
-        }
-      });
-      function readDirectory(reader) {
-        reader.readEntries(function (entries) {
-          if (entries.length) {
-            queue += entries.length;
-            each(entries, function(entry) {
-              if (entry.isFile) {
-                var fullPath = entry.fullPath;
-                entry.file(function (file) {
-                  fileReadSuccess(file, fullPath);
-                }, readError);
-              } else if (entry.isDirectory) {
-                readDirectory(entry.createReader());
-              }
-            });
-            readDirectory(reader);
-          } else {
-            decrement();
+      getEntries(event.dataTransfer.items).then(function (result) {
+        getFiles(result.files).then(function (entries) {
+          var files = [];
+          var errors = [];
+          each(entries, function (entry) {
+            if (entry.error) {
+              errors.push(entry);
+            } else {
+              files.push(entry);
+            }
+          });
+          if (result.errors.length || errors.length) {
+            $.fire('readErrors', errors, result.errors, event);
           }
-        }, readError);
+          if (files.length) {
+            $.addFiles(files, event);
+          }
+        });
+      });
+      function getEntries(items) {
+        var files = [];
+        var errors = [];
+        var promises = [];
+
+        function readEntry(entry, promises) {
+          if (entry.isFile) {
+            files.push(entry);
+          } else if (entry.isDirectory) {
+            promises.push(readDirectory(entry));
+          }
+        }
+
+        function readDirectory(entry) {
+          var reader = entry.createReader();
+          return new Promise(function (resolve, reject) {
+            var promises = [];
+            readEntries(entry, reader, promises, resolve);
+          });
+        }
+
+        function readEntries(entry, reader, promises, resolve) {
+          reader.readEntries(function (entries) {
+            if (entries.length) {
+              var promises2 = [];
+              each(entries, function (entry2) {
+                readEntry(entry2, promises2);
+              });
+              promises.push(Promise.all(promises2));
+              readEntries(entry, reader, promises, resolve);
+              return;
+            }
+            resolve(Promise.all(promises));
+          }, function (error) {
+            errors.push({
+              path: entry.fullPath,
+              error: error
+            });
+            resolve(promises);
+          });
+        }
+
+        each(items, function (item) {
+          var entry = item.webkitGetAsEntry();
+          if (!entry) {
+            return;
+          }
+          if (entry.isFile) {
+            // due to a bug in Chrome's File System API impl - #149735
+            files.push(getFile(item.getAsFile(), entry.fullPath));
+            return;
+          }
+          readEntry(entry, promises);
+        });
+
+        return new Promise(function (resolve, reject) {
+          return Promise.all(promises).then(function () {
+            resolve({ files: files, errors: errors });
+          });
+        });
       }
-      function fileReadSuccess(file, fullPath) {
+      function getFiles(entries) {
+        return Promise.all(entries.map(function (entry) {
+          return new Promise(function (resolve, reject) {
+            if (entry.file) {
+              var fullPath = entry.fullPath;
+              entry.file(function (file) {
+                resolve(getFile(file, fullPath));
+              }, function (file) {
+                resolve({
+                  path: entry.fullPath,
+                  error: file
+                });
+              });
+            } else {
+              resolve(entry);
+            }
+          });
+        }));
+      }
+      function getFile(file, fullPath) {
         // relative path should not start with "/"
         file.relativePath = fullPath.substring(1);
-        files.push(file);
-        decrement();
-      }
-      function readError(fileError) {
-        decrement();
-        throw fileError;
-      }
-      function decrement() {
-        if (--queue == 0) {
-          $.addFiles(files, event);
-        }
+        return file;
       }
     },
 
@@ -588,8 +642,12 @@
      * @param {Event} [event] event is optional
      */
     addFiles: function (fileList, event) {
+      var $ = this;
       var files = [];
-      each(fileList, function (file) {
+      var errors = [];
+      var promises = [];
+
+      function addFile(file) {        
         // https://github.com/flowjs/flow.js/issues/55
         if ((!ie10plus || ie10plus && file.size > 0) && !(file.size % 4096 === 0 && (file.name === '.' || file.fileName === '.'))) {
           var uniqueIdentifier = this.generateUniqueIdentifier(file);
@@ -600,16 +658,54 @@
             }
           }
         }
-      }, this);
-      if (this.fire('filesAdded', files, event)) {
-        each(files, function (file) {
-          if (this.opts.singleFile && this.files.length > 0) {
-            this.removeFile(this.files[0]);
-          }
-          this.files.push(file);
-        }, this);
-        this.fire('filesSubmitted', files, event);
       }
+      
+      /** 
+       * Chrome's FileSystem API has a bug that files from dropped folders or files from input dialog's selected folder,
+       * with read errors (has absolute paths which exceed 260 chars) will have zero file size.
+       */
+      function validateFile(file) {
+        // files with size greater than zero can upload
+        if (file.size > 0) {
+          addFile.bind($)(file);
+          return;
+        }
+        
+        // try to read from from zero size file,
+        // if error occurs than file cannot be uploaded
+        promises.push(new Promise(function (resolve, reject) {
+          var reader = new FileReader();
+          reader.onloadend = function () {
+            if (reader.error) {
+              errors.push({
+                path: file.webkitRelativePath || file.name,
+                error: reader.error
+              });
+            } else {
+              addFile.bind($)(file);
+            }
+            resolve();
+          }.bind($);
+          reader.readAsArrayBuffer(file);
+        }));
+      }
+
+      each(fileList, validateFile);
+
+      Promise.all(promises).then(function () {
+        if (errors.length) {
+          this.fire('readErrors', errors, [], event);
+        }
+        if (this.fire('filesAdded', files, event)) {
+          each(files, function (file) {
+            if (this.opts.singleFile && this.files.length > 0) {
+              this.removeFile(this.files[0]);
+            }
+            this.files.push(file);
+          }, this);
+          this.fire('filesSubmitted', files, event);
+        }
+      }.bind(this));
     },
 
 


### PR DESCRIPTION
Chrome 83.0.4103.61, Windows 10.0.18362 Chrome's FileSystem API has a bug that files from dropped folders or files from input dialog's selected folder, with read errors (has absolute paths which exceed 260 chars) will have zero file size.
When dropped folder has any file with absolute paths which exceeds 260 chars, upload should report read errors.
When input dialog is used to select folder, files with absolute paths which exceeds 260 chars, will be uploaded with zero length. These files should not be uploaded, it should report read errors.

Firefox 76.0.1, Windows 10.0.18362 doesn't have this bug, but it will not upload files with absolute path which exceeds 260 chars.

Edge 44.18362.449.0, Windows 10.0.18362 uploads all files regardless of the absolute path length.


