### PR TITLE
strip console.* in dist/flow.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "npm-check-updates": "^11.0.2",
     "rollup": "^2.37.1",
     "rollup-plugin-istanbul": "^3.0.0",
+    "@rollup/plugin-strip": "^2.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sinon": "^9.2.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import istanbul from 'rollup-plugin-istanbul';
 import pkg from './package.json';
 import replace from '@rollup/plugin-replace';
 import resolve from '@rollup/plugin-node-resolve';
+import strip from '@rollup/plugin-strip';
 import { terser } from "rollup-plugin-terser";
 
 let plugins = [
@@ -30,7 +31,7 @@ export default [
     },
     {
         input: 'src/Flow.js',
-        plugins: plugins.concat([terser()]),
+        plugins: plugins.concat([strip({functions:['console.(log|debug)','debug','alert']}), terser()]),
         output: {
             name: 'Flow',
             banner: `/*! ${pkg.name} ${pkg.version} */\n`,


### PR DESCRIPTION
Addressing a comment from #304

I suggest either:
- to only drop `console.*` from one of the bundle (.js or .min.js) so that the other can be used during test (and still show the output)
- either do it based on an environment variable.

Keeping `console.log` accelerates development and it sounds better to leave to the toolchain the job of striping them when needed.