### PR TITLE
Sauce reporter error

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,26 +22,10 @@ module.exports = function(grunt) {
         singleRun: true,
         browsers: ['Firefox'],
         reporters: ['progress', 'coverage'],
-        preprocessors: {
-          'src/*.js': 'coverage'
-        },
-        coverageReporter: {
-          type: "lcov",
-          dir: "coverage",
-          subdir: "."
-        }
       },
       saucelabs: {
         singleRun: true,
         reporters: ['progress', 'saucelabs'],
-        preprocessors: {
-          'src/*.js': 'coverage'
-        },
-        coverageReporter: {
-          type: "lcov",
-          dir: "coverage",
-          subdir: "."
-        },
         // global config for SauceLabs
         sauceLabs: {
           testName: 'flow.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,9 @@
 module.exports = function(config) {
+  if (config.sauceLabs && (!config.sauceLabs.username || !config.sauceLabs.accessKey)) {
+    console.log('Undefined sauce username/accessKey.');
+    process.exit(1)
+  }
+
   // define SL browsers
   var customLaunchers = {
     sl_ie10: {
@@ -42,6 +47,18 @@ module.exports = function(config) {
       browserName: 'firefox',
       platform: 'Linux',
       version: '42'
+    },
+    sl_ff: {
+      base: 'SauceLabs',
+      browserName: 'firefox',
+      platform: 'Linux',
+      version: '45'
+    },
+    sl_ff_win: {
+      base: 'SauceLabs',
+      browserName: 'firefox',
+      platform: 'Windows 10',
+      version: '80'
     },
     sl_android_1: {
       base: 'SauceLabs',
@@ -99,7 +116,8 @@ module.exports = function(config) {
     ],
 
     preprocessors: {
-      'dist/flow.js': ['coverage']
+      'dist/flow.js': 'coverage',
+      'src/*.js': 'coverage'
     },
 
     // list of files to exclude
@@ -109,7 +127,10 @@ module.exports = function(config) {
 
     // test results reporter to use
     // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-    reporters: ['progress', 'coverage', 'saucelabs'],
+    reporters: ['progress', 'coverage'],
+    coverageReporter: [
+      {type: "lcov", dir: "coverage", subdir: "."}
+    ],
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "karma": "^5.2.2",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.3",
-    "karma-firefox-launcher": "1.3.0",
+    "karma-firefox-launcher": "^1.3.0",
     "karma-jasmine": "4.0",
     "karma-sauce-launcher": "4.1.5",
     "rollup": "^2.26.9",


### PR DESCRIPTION
- In #309 (cfcc849) we updated karma-coverage to v2.
- In #314 (a0eafbc1) we updated karma-sauce-launcher from v0 to v4 but v2 introduced a bug keeping `--single-run=false` from working.
    
This commit:
- moves more of the static Karma configuration from Gruntfile back into karma.conf
- adds two SauceLabs browsers flavors
- adds a guard when karma:saucelabs is used without defined SauceLabs credentials
- disables the saucelabs in the default karma config to restore `--single-run=false` until https://github.com/karma-runner/karma-sauce-launcher/issues/217 is fixed.

