### PR TITLE
Refresh the node-app example

### DIFF
--- a/samples/Node.js/.gitignore
+++ b/samples/Node.js/.gitignore
@@ -1,0 +1,3 @@
+uploads
+!uploads/.keepme
+package-lock.json

--- a/samples/Node.js/app.js
+++ b/samples/Node.js/app.js
@@ -12,7 +12,7 @@ var ACCESS_CONTROLL_ALLOW_ORIGIN = false;
 
 // Host most stuff in the public folder
 app.use(express.static(__dirname + '/public'));
-app.use(express.static(__dirname + '/../../src'));
+app.use(express.static(__dirname + '/../../dist'));
 
 // Handle uploads through Flow.js
 app.post('/upload', multipartMiddleware, function(req, res) {

--- a/samples/Node.js/package.json
+++ b/samples/Node.js/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "connect-multiparty": "^1.0.4",
-    "express": "^4.3.1",
+    "connect-multiparty": "^2.2.0",
+    "express": "^4.17.1",
     "mv": "^2.1.1"
   }
 }

--- a/samples/Node.js/public/index.html
+++ b/samples/Node.js/public/index.html
@@ -53,7 +53,7 @@
             testChunks: false
           });
           // Flow.js isn't supported, fall back on a different method
-          if (!r.support) {
+          if (false) {
             $('.flow-error').show();
             return ;
           }


### PR DESCRIPTION
- Update the app' to take into account that Flow.js itsef does not provide anymore  a way to know whether a given browser is supported.
- Compiled code is now into dist/
- Update to latest dependencies