### PR TITLE
assignBrowse / onDrop: Consider the possibility of an async initFileFn

### DIFF
--- a/src/Flow.js
+++ b/src/Flow.js
@@ -347,8 +347,10 @@ export default class Flow extends Eventizer {
           && this.opts.initFileFn.constructor.name  === 'AsyncFunction'
           ? async e => {
             if (e.target.value) {
+              input.setAttribute('readonly', 'readonly');
               await this.asyncAddFiles(e.target.files, e);
               e.target.value = '';
+              input.removeAttribute('readonly');
             }
           }
           : e => {

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -341,12 +341,23 @@ export default class Flow extends Eventizer {
         input.setAttribute(key, value);
       });
       // When new files are added, simply append them to the overall list
-      input.addEventListener('change', (e) => {
-        if (e.target.value) {
-          this.addFiles(e.target.files, e);
-          e.target.value = '';
-        }
-      }, false);
+      // but adapt to the case where initFileFn is async.
+      var callback = this.opts.initFileFn
+          && typeof this.opts.initFileFn === 'function'
+          && this.opts.initFileFn.constructor.name  === 'AsyncFunction'
+          ? async e => {
+            if (e.target.value) {
+              await this.asyncAddFiles(e.target.files, e);
+              e.target.value = '';
+            }
+          }
+          : e => {
+            if (e.target.value) {
+              this.addFiles(e.target.files, e);
+              e.target.value = '';
+            }
+          };
+      input.addEventListener('change', callback, false);
     }, this);
   }
 

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -143,6 +143,25 @@ export default class Flow extends Eventizer {
   }
 
   /**
+   * On drop event when file/stream initialization is asynchronous
+   * @function
+   * @param {MouseEvent} event
+   */
+  async asyncOnDrop(event) {
+    if (this.opts.onDropStopPropagation) {
+      event.stopPropagation();
+    }
+    event.preventDefault();
+    var dataTransfer = event.dataTransfer;
+    if (dataTransfer.items && dataTransfer.items[0] &&
+        dataTransfer.items[0].webkitGetAsEntry) {
+      this.webkitReadDataTransfer(event);
+    } else {
+      await this.asyncAddFiles(dataTransfer.files, event);
+    }
+  }
+
+  /**
    * Prevent default
    * @function
    * @param {MouseEvent} event
@@ -373,7 +392,11 @@ export default class Flow extends Eventizer {
       domNodes = [domNodes];
     }
 
-    this._onDropBound = this.onDrop.bind(this);
+    this._onDropBound = this.opts.initFileFn
+          && typeof this.opts.initFileFn === 'function'
+          && this.opts.initFileFn.constructor.name  === 'AsyncFunction'
+          ? this.asyncOnDrop.bind(this)
+          : this.onDrop.bind(this);
     for (let domNode of domNodes) {
       domNode.addEventListener('dragover', this.preventEvent, false);
       domNode.addEventListener('dragenter', this.preventEvent, false);


### PR DESCRIPTION
Follow-up of c8dee19bc56 (#329)

When calling `*addFile()`, `FlowChunk` are created which, among other things, imply testing the File size in order to compute the `endByte` (and the *number of chunks*)

*If* an "initFileFn" is declared *AND* this function's prototype shows asynchronicity, then it's sane to assume we need to use `asyncAddFile()` (which will bootstrap slightly differently).

Awaiting for such an `initFileFn` can, for example, allow the chunk size to be computed differently regarding the stream initialization.
An example is a stream-crypto layer that could add an overhead affecting `FlowFile.size`.