### PR TITLE
FlowChunk: xhr abort fixes

### DIFF
--- a/src/FlowChunk.js
+++ b/src/FlowChunk.js
@@ -429,11 +429,10 @@ export default class FlowChunk {
    */
   abort() {
     // Abort and reset
-    var xhr = this.xhr;
-    this.xhr = null;
-    if (xhr) {
-      xhr.abort();
+    if (this.xhr) {
+      this.xhr.abort();
     }
+    this.xhr = null;
   }
 
   /**

--- a/src/FlowChunk.js
+++ b/src/FlowChunk.js
@@ -346,7 +346,7 @@ export default class FlowChunk {
         // We make a fake request so that overall status is "complete" and we can move on
         // on this FlowFile.
         this.pendingRetry = false;
-        this.xhr = {readyState: 5, status: 200, abort: e => null };
+        this.xhr = {readyState: 4, status: 200, abort: e => null };
         this.doneHandler(null);
         return;
       }

--- a/src/FlowChunk.js
+++ b/src/FlowChunk.js
@@ -346,7 +346,7 @@ export default class FlowChunk {
         // We make a fake request so that overall status is "complete" and we can move on
         // on this FlowFile.
         this.pendingRetry = false;
-        this.xhr = {readyState: 5, status: 1 };
+        this.xhr = {readyState: 5, status: 200, abort: e => null };
         this.doneHandler(null);
         return;
       }

--- a/src/FlowChunk.js
+++ b/src/FlowChunk.js
@@ -428,7 +428,6 @@ export default class FlowChunk {
    * @function
    */
   abort() {
-    // Abort and reset
     if (this.xhr) {
       this.xhr.abort();
     }


### PR DESCRIPTION
A couple of fixes regarding `abort()` (observed in the particular case of a stream didn't compute adequately the number of chunks)

(Note: An better codepath is still to be found to replace the current workaround used in `readStreamChunk`)