### PR TITLE
Stop remove file from looping after the correct file is found

### DIFF
--- a/src/Flow.js
+++ b/src/Flow.js
@@ -686,6 +686,10 @@ export default class Flow extends Eventizer {
         this.files.splice(i, 1);
         file.abort();
         this.emit('file-removed', file);
+
+        if (!this.opts.allowDuplicateUploads) {
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
Stopping the loop might have a minor performance benefit.