### PR TITLE
Unduplicate a file-added hook

### DIFF
--- a/src/AsyncFlowFile.js
+++ b/src/AsyncFlowFile.js
@@ -26,9 +26,6 @@ export default class AsyncFlowFile extends FlowFile {
     }
 
     this._bootstrap();
-    if (event !== 'retry') {
-      this.flowObj.hook('file-added', this, event);
-    }
 
     // console.log("Flowfile returns [async]", this._bootstrapped);
     return this;


### PR DESCRIPTION
Having the hook called in AsyncFlowFile may trigger a duplicate event whenever `asyncAddFiles` is called.

Other possibility to rectify this would be to rename `file-added` to `file-inited` or similar, and call it only in AsyncFlowFile's bootstrapping function.