### PR TITLE
Hook and callback changes

### DIFF
--- a/src/Eventizer.js
+++ b/src/Eventizer.js
@@ -359,10 +359,6 @@ export default class extends EventTarget {
 
     this.emitCatchAll(name, ...args);
 
-    if (name === 'file-added' && returns.includes(false)) {
-      console.warn('In Flow.js 3.x, file-added event is an action rather than a filter. Return value is ignored but removing the `file` property allows to skip an enqueued file.');
-    }
-
     return isFilter ? !returns.includes(false) : returns;
   }
 }

--- a/src/Eventizer.js
+++ b/src/Eventizer.js
@@ -322,7 +322,7 @@ export default class extends EventTarget {
       // console.log(`[event] Fire hook "${name}"${args.length ? ' with ' + args.length + ' arguments' : ''}`);
       value = callback.apply(this, args);
       if (name === 'file-added' && value === false) {
-        console.warn('In Flow.js 3.x, file-added event is an action rather than a fitler. return value is ignored but removing the `file` property allows to skip an enqueued file.');
+        console.warn('In Flow.js 3.x, file-added event is an action rather than a filter. Return value is ignored but removing the `file` property allows to skip an enqueued file.');
       }
 
       if (isFilter) {
@@ -347,17 +347,22 @@ export default class extends EventTarget {
    * @return {mixed} In the case of *actions*: The first argument (possibly modified by hooks).
    */
   async aHook(name, ...args) {
-    let calls = this._asyncHooks[name] || [],
-        isFilter = this.isFilter(name);
+    const calls = this._asyncHooks[name] || [],
+          isFilter = this.isFilter(name);
 
     if (! calls.length) {
       return isFilter ? true : args[0];
     }
 
     // console.log(`[event] Fire ${calls.length} async hook for "${name}"${args.length ? ' with ' + args.length + ' arguments' : ''}`);
-    var returns = await Promise.all(calls.map(e => e.apply(this, args)));
+    const returns = await Promise.all(calls.map(e => e.apply(this, args)));
 
     this.emitCatchAll(name, ...args);
-    return isFilter ? returns.include(false) : returns;
+
+    if (name === 'file-added' && returns.includes(false)) {
+      console.warn('In Flow.js 3.x, file-added event is an action rather than a filter. Return value is ignored but removing the `file` property allows to skip an enqueued file.');
+    }
+
+    return isFilter ? !returns.includes(false) : returns;
   }
 }

--- a/test/fileAddSpec.js
+++ b/test/fileAddSpec.js
@@ -87,6 +87,29 @@ describe('fileAdd event', function() {
     expect(valid).toBeTruthy();
   });
 
+  it('should validate multiple filter-file aHooks', async function() {
+    const customFunction = jasmine.createSpy('fn');
+    flow.on('filter-file', async () => {
+      customFunction();
+      return true;
+    });
+    flow.on('filter-file', async () => {
+      customFunction();
+      return false; // a single hook returning false should prevail
+    });
+    flow.on('filter-file', async () => {
+      customFunction();
+      return true;
+    });
+    let valid = false;
+    flow.on('files-added', (files) => {
+      valid = files.length === 0;
+    });
+    await flow.asyncAddFile(new Blob(['file part']));
+    expect(valid).toBeTruthy();
+    expect(customFunction).toHaveBeenCalledTimes(3);
+  });
+
   describe('async/sync hooks', function () {
     beforeAll(function() {
       jasmine.getEnv().addReporter({


### PR DESCRIPTION
* Adds the same warning about filtering in file-added to aHook than in the synchronous hook and fixes a typo in it
* Fixes calling emitCatchAll in aHook when there's no user defined callback
* Fixes a typo with Array.prototype.includes in aHook
* Fixes inverted logic with filter-file's callback in aHook
* Styling: changed let and var to const