### PR TITLE
 GitHub action to detect changed-files (test PR)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           echo $SAUCE_USERNAME
           echo ${{ github.event.pull_request.base.sha }}  ${{ github.sha }} ${{ github.event.pull_request.head.sha }}
+          echo abcd
 
       - name: Get specific changed files
         id: source-changed


### PR DESCRIPTION
`pull_request_target` implies the **workflow is fetched from the base branch**.
We thus need to test a "modified base branch" (which is `feature/github-action`) if we don't want to test (and mess with) `v3` 

**This PR is just intended to test #366** (it needs to be rebased everytime to test workflow changes)