### PR TITLE
Validate the firing order of hooks and catch-all

### DIFF
--- a/test/fileAddSpec.js
+++ b/test/fileAddSpec.js
@@ -118,6 +118,18 @@ describe('fileAdd event', function() {
     expect(customFunction).toHaveBeenCalledTimes(3);
   });
 
+  it('should validate catch-all emitting after hooks', async function() {
+    let valid = false;
+    flow.on('catch-all', () => {
+      valid = true;
+    });
+    flow.on('files-submitted', () => {
+      valid = false;
+    });
+    await flow.addFile(new Blob(['file part']));
+    expect(valid).toBeTruthy();
+  });
+
   describe('async/sync hooks', function () {
     beforeAll(function() {
       jasmine.getEnv().addReporter({


### PR DESCRIPTION
Adds a test to make sure that [Eventizer.js](https://github.com/flowjs/flow.js/blob/b0d603fc01f231442fab8f9979609b4dfe174e45/src/Eventizer.js#L319) fires hooks and events always in the same order.