### PR TITLE
Bump grunt version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/flowjs/flow.js/issues"
   },
   "devDependencies": {
-    "grunt": "0.4.5",
+    "grunt": "1.4.1",
     "grunt-bump": "0.7.0",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-concat": "1.0.0",


### PR DESCRIPTION
@AidasK: I created this patch that i think could work like a charm but actually i see that tests seems to not start.

Probably its due to the fact that we still need to migrate from travis-ci.org to travis-ci.com.

Will try to check on this later.